### PR TITLE
Use base layer WMS version instead of custom property

### DIFF
--- a/src/leaflet.timedimension.layer.wms.js
+++ b/src/leaflet.timedimension.layer.wms.js
@@ -8,7 +8,7 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
         L.TimeDimension.Layer.prototype.initialize.call(this, layer, options);
         this._timeCacheBackward = this.options.cacheBackward || this.options.cache || 0;
         this._timeCacheForward = this.options.cacheForward || this.options.cache || 0;
-        this._wmsVersion = this.options.wmsVersion || "1.1.1";
+        this._wmsVersion = this.options.wmsVersion || this.options.version || "1.1.1";
         this._proxy = this.options.proxy || null;
         this._updateTimeDimension = this.options.updateTimeDimension || false;
         this._setDefaultTime = this.options.setDefaultTime || false;

--- a/src/leaflet.timedimension.layer.wms.js
+++ b/src/leaflet.timedimension.layer.wms.js
@@ -8,7 +8,7 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
         L.TimeDimension.Layer.prototype.initialize.call(this, layer, options);
         this._timeCacheBackward = this.options.cacheBackward || this.options.cache || 0;
         this._timeCacheForward = this.options.cacheForward || this.options.cache || 0;
-        this._wmsVersion = this.options.wmsVersion || this.options.version || "1.1.1";
+        this._wmsVersion = this.options.wmsVersion || this.options.version || layer.options.version || "1.1.1";
         this._proxy = this.options.proxy || null;
         this._updateTimeDimension = this.options.updateTimeDimension || false;
         this._setDefaultTime = this.options.setDefaultTime || false;


### PR DESCRIPTION
Leaflet use ```version``` option to declare WMS server version.
This PR complies with this name.

Also use the baseLayer version if no option has been set.
