### PR TITLE
Use baseLayer constructor to create a new Layer

### DIFF
--- a/src/leaflet.timedimension.layer.wms.js
+++ b/src/leaflet.timedimension.layer.wms.js
@@ -171,12 +171,8 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
         var wmsParams = this._baseLayer.options;
         wmsParams.time = new Date(nearestTime).toISOString();
 
-        var newLayer = null;
-        if (this._baseLayer instanceof L.TileLayer) {
-            newLayer = L.tileLayer.wms(this._baseLayer.getURL(), wmsParams);
-        } else {
-            newLayer = L.nonTiledLayer.wms(this._baseLayer.getURL(), wmsParams);
-        }
+        var newLayer = new this._baseLayer.constructor(this._baseLayer.getURL(), wmsParams);
+
         this._layers[time] = newLayer;
 
         newLayer.on('load', (function(layer, time) {


### PR DESCRIPTION
instead of guessing it with instanceof, we use the real one.

This allows to use subclasses of L.WMS and L.NT.WMS as base layer.
(or any layer that implements mandatory methods)