### PR TITLE
Update leaflet.timedimension.js

### DIFF
--- a/src/leaflet.timedimension.js
+++ b/src/leaflet.timedimension.js
@@ -103,8 +103,7 @@ L.TimeDimension = (L.Layer || L.Class).extend({
         for (var i = 0, len = this._syncedLayers.length; i < len; i++) {
             if (this._syncedLayers[i].isReady) {
                 if (!this._syncedLayers[i].isReady(time)) {
-                    if (map.getBounds().contains(this._syncedLayers[i]._baseLayer.options.bounds))
-                        return false;                    
+					return false;                    
                 }
             }
         }

--- a/src/leaflet.timedimension.js
+++ b/src/leaflet.timedimension.js
@@ -98,18 +98,19 @@ L.TimeDimension = (L.Layer || L.Class).extend({
         });
         this._loadingTimeIndex = -1;
     },
-
+    
     _checkSyncedLayersReady: function (time) {
         for (var i = 0, len = this._syncedLayers.length; i < len; i++) {
             if (this._syncedLayers[i].isReady) {
                 if (!this._syncedLayers[i].isReady(time)) {
-                    return false;
+                    if (map.getBounds().contains(this._syncedLayers[i]._baseLayer.options.bounds))
+                        return false;                    
                 }
             }
         }
         return true;
     },
-
+    
     setCurrentTime: function (time) {
         var newIndex = this._seekNearestTimeIndex(time);
         this.setCurrentTimeIndex(newIndex);

--- a/src/leaflet.timedimension.layer.wms.js
+++ b/src/leaflet.timedimension.layer.wms.js
@@ -58,6 +58,9 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
 
     isReady: function(time) {
         var layer = this._getLayerForTime(time);
+        if (this.options.bounds && this._map)
+            if (!this._map.getBounds().contains(this.options.bounds))
+                return true;
         return layer.isLoaded();
     },
 


### PR DESCRIPTION
When one or more layers with limited bounds are out the visible map, isReady(time) nevere return true.
Happens only with L.tileLayer.wms and only loading more than one layer on TimeDimension

with this code:
    var URL='http://thredds.emodnet-physics.eu/thredds/wms/fmrc/SOCIBlast60days/Socib_Last_60_Days_Socib_HFRadar?'
    var radarSource = new L.tileLayer.wms(settings.URLProxy, {      layers: 'sea_water_velocity',
        format: 'image/png',
        transparent: true,
        colorscalerange: '0,0.75',
        abovemaxcolor: "extend",
        belowmincolor: "extend",
        bounds: [["38.323", "0.50384"], ["39.1067", "1.40066"]],
    }).addTo(map);
    var radarTimeLayer = L.timeDimension.layer.wms(radarSource, {
        updateTimeDimension: true,
        name: 'sea_water_velocity',
        units: "m/s",
    }).addTo(map);
.....more layer added to "L.timeDimension.layer.wms" in the same way

when the visible bounds does not contains L.latLngBounds(["38.323", "0.50384"], [["39.1067", "1.40066"]), isReady is always false
