### PR TITLE
Change dependency of iso8601

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "git://github.com/socib/Leaflet.TimeDimension.git"
   },
   "dependencies": {
-    "iso8601-js-period": "*",
+    "iso8601-js-period": "0.2.0",
     "leaflet": "~0.7.4 || ~1.0.0",
     "jquery": "1.x || 2.x"
   },


### PR DESCRIPTION
Due to recent publish of iso8601-js-period as a npm package, we now can install Leaflet.TimeDimension with a 

`npm install socib/Leaflet.TimeDimension`

After a publishing on npmjs via a `npm publish`, we could install it with a simple

`npm install leaflet-timedimension`

Hope this will help !

related to #87 