### PR TITLE
Change so pre-1970 datetimes work

### DIFF
--- a/src/leaflet.timedimension.control.js
+++ b/src/leaflet.timedimension.control.js
@@ -304,9 +304,8 @@ L.Control.TimeDimension = L.Control.extend({
         if (!this._timeDimension) {
             return;
         }
-        var time = this._timeDimension.getCurrentTime();
-        if (time > 0) {
-            var date = new Date(time);
+        if (this._timeDimension.getCurrentTimeIndex() >= 0) {
+            var date = new Date(this._timeDimension.getCurrentTime());
             if (this._displayDate) {
                 L.DomUtil.removeClass(this._displayDate, 'loading');
                 this._displayDate.innerHTML = this._getDisplayDateFormat(date);

--- a/src/leaflet.timedimension.js
+++ b/src/leaflet.timedimension.js
@@ -50,7 +50,7 @@ L.TimeDimension = (L.Layer || L.Class).extend({
         if (index >= 0) {
             return this._availableTimes[index];
         } else {
-            return 0;
+            return null;
         }
     },
 


### PR DESCRIPTION
Currently the control widget doesn't allow dates before 1970 because it does a check to see if the time is greater than 0. Since dates before 1970 will be negative (in milliseconds), I changed this to check the time index. Fixes issue #83.

Additionally, I think the getCurrentTime function should return null rather than 0, if there is no current time index.