### PR TITLE
Using GeoWebCache with leaflet.timedimension.layer.wms.js 

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,8 @@ Option                | Default       | Description
 `requestTimeFromCapabilities` | `false || updateTimeDimension` | Get list of available times for this layer from getCapabilities 
 `proxy`               | `null`        | URL of the proxy used to obtain getCapabilities responses from the WMS server avoiding cross site origin problems
 `getCapabilitiesParams` | `{}`        | Extra parameters needed to create getCapabilities request
+`getCapabilitiesUrl`    | `null`      | Alternative URL for the GetCapabilities request (useful if using a cache service like GeoWebCache) 
+`getCapabilitiesLayerName`| `null`    | Alternative layer name for the GetCapabilities request (useful if using a cache service like GeoWebCache)
 `setDefaultTime`      | `false`       | If true, it will change the current time to the default time of the layer (according to getCapabilities)
 `wmsVersion`          | `"1.1.1" || layer.options.version`     | WMS version of the layer. Used to construct the getCapabilities request
 

--- a/src/leaflet.timedimension.layer.wms.js
+++ b/src/leaflet.timedimension.layer.wms.js
@@ -10,6 +10,8 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
         this._timeCacheForward = this.options.cacheForward || this.options.cache || 0;
         this._wmsVersion = this.options.wmsVersion || this.options.version || layer.options.version || "1.1.1";
         this._getCapabilitiesParams = this.options.getCapabilitiesParams || {};
+        this._getCapabilitiesAlternateUrl = this.options.getCapabilitiesUrl || null;
+        this._getCapabilitiesAlternateLayerName = this.options.getCapabilitiesLayerName || null;
         this._proxy = this.options.proxy || null;
         this._updateTimeDimension = this.options.updateTimeDimension || false;
         this._setDefaultTime = this.options.setDefaultTime || false;
@@ -264,6 +266,8 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
 
     _getCapabilitiesUrl: function() {
         var url = this._baseLayer.getURL();
+        if (this._getCapabilitiesAlternateUrl)
+            url = this._getCapabilitiesAlternateUrl
         var params = L.extend({}, this._getCapabilitiesParams, {
           'request': 'GetCapabilities',
           'service': 'WMS',
@@ -276,6 +280,8 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
     _parseTimeDimensionFromCapabilities: function(xml) {
         var layers = $(xml).find('Layer[queryable="1"]');
         var layerName = this._baseLayer.wmsParams.layers;
+        if (this._getCapabilitiesAlternateLayerName)
+            layerName = this._getCapabilitiesAlternateLayerName;
         var layerNameElement = layers.find("Name").filter(function(index) {
             return $(this).text() === layerName;
         });
@@ -307,6 +313,8 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
     _getDefaultTimeFromCapabilities: function(xml) {
         var layers = $(xml).find('Layer[queryable="1"]');
         var layerName = this._baseLayer.wmsParams.layers;
+        if (this._getCapabilitiesAlternateLayerName)
+            layerName = this._getCapabilitiesAlternateLayerName;
         var layerNameElement = layers.find("Name").filter(function(index) {
             return $(this).text() === layerName;
         });

--- a/src/leaflet.timedimension.layer.wms.js
+++ b/src/leaflet.timedimension.layer.wms.js
@@ -267,7 +267,7 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
     _getCapabilitiesUrl: function() {
         var url = this._baseLayer.getURL();
         if (this._getCapabilitiesAlternateUrl)
-            url = this._getCapabilitiesAlternateUrl
+            url = this._getCapabilitiesAlternateUrl;
         var params = L.extend({}, this._getCapabilitiesParams, {
           'request': 'GetCapabilities',
           'service': 'WMS',


### PR DESCRIPTION
Using GeoWebCache, the GetCapabilities method does not contains the time dimension. I need to access the original WMS server to retrieve the correct data. Also, using GeoWebCache, the layer name can be different from the layer on the original WMS server, so I need the correc  layer name on the original WMS server.

Added the "getCapabilitiesUrl" to specify an alternate url for the GetCapabilities request

Added the "getCapabilitiesLayerName" to specify an alternate layer name for the GetCapabilities request