### PR TITLE
Keep number of steps when changing transition time

### DIFF
--- a/src/leaflet.timedimension.player.js
+++ b/src/leaflet.timedimension.player.js
@@ -154,7 +154,7 @@ L.TimeDimension.Player = (L.Layer || L.Class).extend({
         }
         if (this._intervalID) {
             this.stop();
-            this.start();
+            this.start(this._steps);
         }
         this.fire('speedchange', {
             transitionTime: transitionTime,


### PR DESCRIPTION
Changing the frame rate / transition time resets the number of steps to 1. When you have a different number of steps (for example, reverse playing, with -1 steps), and change the frame rate, having the number of steps change back to 1 is kind of annoying. So this small change reuses the current number of steps for playing when the transition time is changed.