### PR TITLE
Replace reverse play `rotate` transform with `scaleX`

### DIFF
--- a/src/leaflet.timedimension.control.css
+++ b/src/leaflet.timedimension.control.css
@@ -224,10 +224,9 @@
 }*/
 .timecontrol-play.reverse:before {
     content: "\e072";
-    -ms-transform: rotate(180deg);
-    -webkit-transform: rotate(180deg);
-    transform: rotate(180deg);
-    margin-top: 1px;
+    -ms-transform: scaleX(-1);
+    -webkit-transform: scaleX(-1);
+    transform: scaleX(-1);
 }
 .timecontrol-play.pause:before {
     content: "\e073";
@@ -236,7 +235,6 @@
     -ms-transform: none;
     -webkit-transform: none;
     transform: none;
-    margin-top: 0;
 }
 
 a.timecontrol-play.loading:before {


### PR DESCRIPTION
The reverse play button height is inconsistent across browsers (see the image below, from Chrome on Android), apparently due to the `rotate` css transformation. When using `scaleX` to flip the icon instead, the height stays consistent across browsers and the player controls stay aligned with each other.

![timedimension_reverse_play_small](https://user-images.githubusercontent.com/4205859/29781174-55ec4342-8be6-11e7-8cbd-7c06559d5255.png)

Here's the same site after applying the css `scaleX` fix:

![timedimension_reverse_play_fixed_small](https://user-images.githubusercontent.com/4205859/29781566-9950308e-8be7-11e7-9a96-29c90e86c8f1.png)
