### PR TITLE
removed jquery dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -52,9 +52,7 @@ module.exports = function(grunt) {
         concat: {
             js: {
                 options: {
-                    banner: '<%= meta.banner %>' + 
-                        '(function($){',
-                    footer: '})(jQuery);'
+                    banner: '<%= meta.banner %>'
                 },
                 src: [
                     'src/leaflet.timedimension.js',

--- a/bower.json
+++ b/bower.json
@@ -28,8 +28,8 @@
       "email": "datacenter@socib.es",
       "homepage": "http://www.socib.es/"
     },
-    { 
-      "name": "Sylvain Marcadal (Ram)", 
+    {
+      "name": "Sylvain Marcadal (Ram)",
       "email":"sylvain@marcadal.me"
     }
   ],
@@ -40,7 +40,6 @@
   },
   "dependencies": {
     "iso8601-js-period": "*",
-    "leaflet": "~0.7.4 || ~1.0.0",
-    "jquery": "1.x || 2.x"
+    "leaflet": "~0.7.4 || ~1.0.0"
   }
 }

--- a/examples/example1.html
+++ b/examples/example1.html
@@ -54,7 +54,7 @@
            oReq.addEventListener("load", (function(xhr) {
              var code = xhr.currentTarget.response;
              var codeBlock = document.getElementById("code");
-             codeBlock.innerHTML = code;
+             codeBlock.textContent = code;
              hljs.highlightBlock(codeBlock);
            }));
            oReq.open("GET", "js/example1.js");

--- a/examples/example1.html
+++ b/examples/example1.html
@@ -14,26 +14,25 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 1</h1>                
+                <h1>Leaflet TimeDimension example 1</h1>
                 <h2>Daily altimetry from satellite (AVISO)</h2>
             </div>
             <div id="map" class="map"></div>
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>     
+            <pre><code class="javascript" id="code"></code></pre>
             <div class="prev-example">
                 <a href="index.html">Index</a>
-            </div>                     
+            </div>
             <div class="next-example">
                 <a href="example2.html">Example 2: Temperature from IBL Software Engineering</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -51,15 +50,15 @@
 
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example1.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
+           var oReq = new XMLHttpRequest();
+           oReq.addEventListener("load", (function(xhr) {
+             var code = xhr.currentTarget.response;
+             var codeBlock = document.getElementById("code");
+             codeBlock.innerHTML = code;
+             hljs.highlightBlock(codeBlock);
+           }));
+           oReq.open("GET", "js/example1.js");
+           oReq.send();
         </script>
 
     </body>

--- a/examples/example10.html
+++ b/examples/example10.html
@@ -74,7 +74,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example10.js");

--- a/examples/example10.html
+++ b/examples/example10.html
@@ -14,12 +14,12 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 10</h1>                
+                <h1>Leaflet TimeDimension example 10</h1>
                 <h2>ImageOverlay and custom control</h2>
             </div>
-            <div id="map-wrapper"> 
+            <div id="map-wrapper">
                 <div id="map" class="map sirena"></div>
-                <div id="mapcontrol" class="sidecontrol">                    
+                <div id="mapcontrol" class="sidecontrol">
                     <span class="title"><a href="http://socib.es/?seccion=observingFacilities&facility=mooring&id=36" title="Mobims Cala Millor">Beach Monitoring at Cala Millor</a></span>
                     <span class="date">&nbsp;</span>
                     <span class="time">&nbsp;</span>
@@ -36,22 +36,21 @@
 
             <h2>Description</h2>
             <p>This is a <i>proof-of-concept</i>. We have implemented a new L.TimeDimension.Layer class to manage ImageOverlays and a basic custom control to manage the TimeDimension.</p>
-            <p>The chart shows the daily wind average observed at the weather station installed in Cala Millor by SOCIB. If you click in any point of the chart, it will show the image of the selected date at 12:00h.</p>            
+            <p>The chart shows the daily wind average observed at the weather station installed in Cala Millor by SOCIB. If you click in any point of the chart, it will show the image of the selected date at 12:00h.</p>
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example9.html">Example 9: GeoJSON layers with times property</a>
-            </div>   
+            </div>
             <div class="next-example">
                 <a href="example11.html">Example 11: NOAA Operational Climate Data Records (SST)</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>            
+            </div>
         </div>
-
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
@@ -71,15 +70,15 @@
         <script type="text/javascript" src="js/example10.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example10.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example10.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example11.html
+++ b/examples/example11.html
@@ -16,38 +16,37 @@
             padding-left: 30px !important;
             font-weight: bold;
         }
-        </style>        
+        </style>
     </head>
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 11</h1>                
+                <h1>Leaflet TimeDimension example 11</h1>
                 <h2>Sea Surface Temperature from <a href="http://www.ncdc.noaa.gov/cdr/operationalcdrs.html">NOAA Operational Climate Data Records</a></h2>
             </div>
             <div id="map" class="map"></div>
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example10.html">Example 10: ImageOverlay and custom control</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="example12.html">Example 12: Noise-Commercial complaints from NYC OpenData</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
-        
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
         <script type="text/javascript" src="https://cdn.rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"></script>
-        <script type="text/javascript" src="https://rawgit.com/felixge/node-dateformat/master/lib/dateformat.js"></script>        
+        <script type="text/javascript" src="https://rawgit.com/felixge/node-dateformat/master/lib/dateformat.js"></script>
 
         <script type="text/javascript" src="../src/leaflet.timedimension.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.util.js"></script>
@@ -60,15 +59,15 @@
         <script type="text/javascript" src="js/example11.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example11.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example11.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example11.html
+++ b/examples/example11.html
@@ -63,7 +63,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example11.js");

--- a/examples/example12.html
+++ b/examples/example12.html
@@ -21,56 +21,55 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 12</h1>                
+                <h1>Leaflet TimeDimension example 12</h1>
                 <h2>Noise-Commercial complaints from <a href="https://nycopendata.socrata.com/Social-Services/311-Service-Requests-from-2010-to-Present/erm2-nwe9">NYC OpenData</a></h2>
             </div>
             <div id="map" class="map"></div>
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example11.html">Example 11: NOAA Operational Climate Data Records (SST)</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="example13.html">Example 13: Demo of L.TimeDimension.WMS.timeseries Layer</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
         <script type="text/javascript" src="https://cdn.rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"></script>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/heatmap.js/2.0.2/heatmap.min.js"></script>        
+        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/heatmap.js/2.0.2/heatmap.js"></script>
         <script type="text/javascript" src="https://rawgit.com/pa7/heatmap.js/develop/plugins/leaflet-heatmap/leaflet-heatmap.js"></script>
         <script type="text/javascript" src="http://maps.stamen.com/js/tile.stamen.js?v1.3.0"></script>
-        <script type="text/javascript" src="https://rawgit.com/felixge/node-dateformat/master/lib/dateformat.js"></script>        
-        
+        <script type="text/javascript" src="https://rawgit.com/felixge/node-dateformat/master/lib/dateformat.js"></script>
+
         <script type="text/javascript" src="../src/leaflet.timedimension.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.util.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.wms.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.geojson.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.player.js"></script>
-        <script type="text/javascript" src="../src/leaflet.timedimension.control.js"></script>        
+        <script type="text/javascript" src="../src/leaflet.timedimension.control.js"></script>
         <script type="text/javascript" src="js/baselayers.js"></script>
         <script type="text/javascript" src="js/example12.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example12.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example12.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example12.html
+++ b/examples/example12.html
@@ -65,7 +65,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example12.js");

--- a/examples/example13.html
+++ b/examples/example13.html
@@ -9,12 +9,12 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.css">
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.css">
         <link rel="stylesheet" href="../src/leaflet.timedimension.control.css" />
-        <link rel="stylesheet" href="css/style.css" />      
+        <link rel="stylesheet" href="css/style.css" />
     </head>
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 13</h1>                
+                <h1>Leaflet TimeDimension example 13</h1>
                 <h2>TimeSeries in a point (for WMS layers provided through a THREDDS Data Server)</h2>
             </div>
             <div id="map" class="map"></div>
@@ -36,21 +36,21 @@
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example12.html">Example 12: Noise-Commercial complaints from NYC OpenData</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="example14.html">Example 14: NOAA's nowCOAST weather radar</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -63,23 +63,23 @@
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.wms.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.geojson.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.player.js"></script>
-        <script type="text/javascript" src="../src/leaflet.timedimension.control.js"></script>        
-        <script type="text/javascript" src="js/extras/leaflet.timedimension.circlelabelmarker.js"></script>        
-        <script type="text/javascript" src="js/extras/leaflet.timedimension.layer.wms.timeseries.js"></script>        
+        <script type="text/javascript" src="../src/leaflet.timedimension.control.js"></script>
+        <script type="text/javascript" src="js/extras/leaflet.timedimension.circlelabelmarker.js"></script>
+        <script type="text/javascript" src="js/extras/leaflet.timedimension.layer.wms.timeseries.js"></script>
 
         <script type="text/javascript" src="js/baselayers.js"></script>
         <script type="text/javascript" src="js/example13.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example13.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example13.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example13.html
+++ b/examples/example13.html
@@ -75,7 +75,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example13.js");

--- a/examples/example14.html
+++ b/examples/example14.html
@@ -9,12 +9,12 @@
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.css" />
         <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.css" />
         <link rel="stylesheet" href="../src/leaflet.timedimension.control.css" />
-        <link rel="stylesheet" href="css/style.css" />      
+        <link rel="stylesheet" href="css/style.css" />
     </head>
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 14</h1>                
+                <h1>Leaflet TimeDimension example 14</h1>
                 <h2>NOAA's nowCOAST weather radar</h2>
             </div>
             <div id="map" class="map"></div>
@@ -28,21 +28,21 @@
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example13.html">Example 13: Demo of L.TimeDimension.WMS.timeseries Layer</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="example15.html">Example 15: Oil Spill simulation</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -59,15 +59,15 @@
         <script type="text/javascript" src="js/example14.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example14.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example14.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example14.html
+++ b/examples/example14.html
@@ -63,7 +63,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example14.js");

--- a/examples/example15.html
+++ b/examples/example15.html
@@ -15,7 +15,7 @@
                 padding: 0; list-style: none;
             }
             .legend li{
-                padding: 5px;                
+                padding: 5px;
             }
             .legend li.p05{
                 background-color: #00FF00;
@@ -34,11 +34,11 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example Oil Spill</h1>                
+                <h1>Leaflet TimeDimension example Oil Spill</h1>
                 <h2>Oil Spill simulation</h2>
             </div>
             <div id="map" class="map">
-                <div class="animation-progress-bar"></div>                
+                <div class="animation-progress-bar"></div>
             </div>
             <h2>Information</h2>
             <div class="information">
@@ -47,21 +47,21 @@
             </div>
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example14.html">Example 14: NOAA's nowCOAST weather radar</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="example16.html">Example 16: Portus wave forecast</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -77,15 +77,15 @@
         <script type="text/javascript" src="js/example15.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example15.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example15.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example15.html
+++ b/examples/example15.html
@@ -81,7 +81,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example15.js");

--- a/examples/example16.html
+++ b/examples/example16.html
@@ -63,7 +63,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example16.js");
@@ -72,7 +72,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code-portus");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/extras/leaflet.timedimension.tilelayer.portus.js");

--- a/examples/example16.html
+++ b/examples/example16.html
@@ -13,7 +13,7 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 16</h1>                
+                <h1>Leaflet TimeDimension example 16</h1>
                 <h2><a href="http://portus.puertos.es/Portus_RT/?locale=es">Portus</a> Wave forecast</h2>
             </div>
             <div id="map" class="map"></div>
@@ -26,22 +26,22 @@
             </div>
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
             <h2>Code of L.TimeDimension.Layer.TileLayer.Portus</h2>
-            <pre><code class="javascript" id="code-portus"></code></pre>            
+            <pre><code class="javascript" id="code-portus"></code></pre>
 
             <div class="prev-example">
                 <a href="example16.html">Example 15: Oil Spill simulation</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="index.html">Index</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -59,22 +59,24 @@
         <script type="text/javascript" src="js/example16.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example16.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('#code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-                $.ajax('js/extras/leaflet.timedimension.tilelayer.portus.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code-portus").text(response);
-                        $('#code-portus').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example16.js");
+            oReq.send();
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code-portus");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/extras/leaflet.timedimension.tilelayer.portus.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example2.html
+++ b/examples/example2.html
@@ -14,12 +14,12 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 2</h1>                
+                <h1>Leaflet TimeDimension example 2</h1>
                 <h2>Temperature from <a href="http://www.iblsoft.com/">IBL Software Engineering</a></h2>
             </div>
             <div id="map" class="map"></div>
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
             <div class="prev-example">
                 <a href="example1.html">Example 1: Daily altimetry from satellite</a>
             </div>
@@ -29,10 +29,10 @@
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                            
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="https://cdn.rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"></script>
@@ -47,15 +47,15 @@
         <script type="text/javascript" src="js/example2.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example2.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example2.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example2.html
+++ b/examples/example2.html
@@ -51,7 +51,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example2.js");

--- a/examples/example3.html
+++ b/examples/example3.html
@@ -15,7 +15,7 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 3</h1>                
+                <h1>Leaflet TimeDimension example 3</h1>
                 <h2>SOCIB HF RADAR</h2>
             </div>
             <div id="map" class="map radar"></div>
@@ -25,7 +25,7 @@
                 <label for="start_time">Start time (local time)</label><br/><input id="dtp_start" name="start_time" type="text" >
                 </div>
                 <div style="float:left; margin-right: 10px;">
-                <label for="end_time">End time (local time)</label><br/><input id="dtp_end" name="end_time" type="text" >                
+                <label for="end_time">End time (local time)</label><br/><input id="dtp_end" name="end_time" type="text" >
                 </div>
                 <div style="float:left; padding-top: 100px;">
                     <button type="button" id="btn_timerange" class="btn" >Apply new time availables range</button><br /><br />
@@ -35,7 +35,7 @@
             <div style="clear: both;"></div>
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
             <div class="prev-example">
                 <a href="example2.html">Example 2: Temperature from IBL Software Engineering</a>
             </div>
@@ -45,7 +45,7 @@
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
@@ -59,21 +59,21 @@
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.wms.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.player.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.control.js"></script>
-        
+
         <script type="text/javascript" src="js/example3.js"></script>
 
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example3.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example3.js");
+            oReq.send();
+       </script>
 
     </body>
 </html>

--- a/examples/example3.html
+++ b/examples/example3.html
@@ -68,7 +68,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example3.js");

--- a/examples/example4.html
+++ b/examples/example4.html
@@ -14,14 +14,14 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 4</h1>                
+                <h1>Leaflet TimeDimension example 4</h1>
                 <h2>Radar precipitation measurements above the Netherlands (from <a href="http://www.knmi.nl/">KNMI</a>)</h2>
             </div>
             <div id="map" class="map"></div>
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example3.html">Example 3: SOCIB HF Radar</a>
@@ -32,9 +32,8 @@
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>              
+            </div>
         </div>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -45,19 +44,19 @@
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.wms.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.player.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.control.js"></script>
-        
+
         <script type="text/javascript" src="js/example4.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example4.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example4.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example4.html
+++ b/examples/example4.html
@@ -52,7 +52,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example4.js");

--- a/examples/example5.html
+++ b/examples/example5.html
@@ -54,7 +54,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example5.js");

--- a/examples/example5.html
+++ b/examples/example5.html
@@ -14,13 +14,13 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 5</h1>                
+                <h1>Leaflet TimeDimension example 5</h1>
                 <h2>Climate projection from <a href="https://www.pik-potsdam.de/">Postdam Institute for Climate Impact Research</a></h2>
             </div>
             <div id="map" class="map"></div>
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example4.html">Example 4: Radar precipitation measurements</a>
@@ -31,10 +31,10 @@
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="https://cdn.rawgit.com/nezasa/iso8601-js-period/master/iso8601.min.js"></script>
@@ -46,19 +46,19 @@
         <script type="text/javascript" src="../src/leaflet.timedimension.layer.wms.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.player.js"></script>
         <script type="text/javascript" src="../src/leaflet.timedimension.control.js"></script>
-        
+
         <script type="text/javascript" src="js/example5.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example5.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example5.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example6.html
+++ b/examples/example6.html
@@ -54,7 +54,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example6.js");

--- a/examples/example6.html
+++ b/examples/example6.html
@@ -14,27 +14,27 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 6</h1>                
+                <h1>Leaflet TimeDimension example 6</h1>
                 <h2>SOCIB Wave Forecast (SAPO IB)</h2>
             </div>
             <div id="map" class="map"></div>
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example5.html">Example 5: Climate projections</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="example7.html">Example 7: SOCIB WMOP Ocean Forecast</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -50,15 +50,15 @@
         <script type="text/javascript" src="js/example6.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example6.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example6.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example7.html
+++ b/examples/example7.html
@@ -14,28 +14,28 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 7</h1>                
+                <h1>Leaflet TimeDimension example 7</h1>
                 <h2>SOCIB WMOP (The Western Mediterranean Operational system)</h2>
             </div>
             <div id="map" class="map"></div>
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example6.html">Example 6: SOCIB Wave Forecast (SAPO IB)</a>
-            </div>   
+            </div>
             <div class="next-example">
                 <a href="example8.html">Example 8: SOCIB HF Radar with surface drifters trajectories</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -50,15 +50,15 @@
         <script type="text/javascript" src="js/example7.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example7.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example7.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example7.html
+++ b/examples/example7.html
@@ -54,7 +54,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example7.js");

--- a/examples/example8.html
+++ b/examples/example8.html
@@ -53,7 +53,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example8.js");

--- a/examples/example8.html
+++ b/examples/example8.html
@@ -14,27 +14,27 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 8</h1>                
+                <h1>Leaflet TimeDimension example 8</h1>
                 <h2>SOCIB HF Radar with surface drifters trajectories</h2>
             </div>
             <div id="map" class="map"></div>
 
 
             <h2>Code</h2>
-            <pre><code class="javascript" id="code"></code></pre>            
+            <pre><code class="javascript" id="code"></code></pre>
 
             <div class="prev-example">
                 <a href="example7.html">Example 7: SOCIB WMOP Ocean Forecast</a>
-            </div>                 
+            </div>
             <div class="next-example">
                 <a href="example9.html">Example 9: GeoJSON layers with times property</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/1.0.0-rc.2/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
         <script type="text/javascript" src="js/vendor/NonTiledLayer.js"></script>
@@ -49,15 +49,15 @@
         <script type="text/javascript" src="js/example8.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example8.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example8.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example9.html
+++ b/examples/example9.html
@@ -14,7 +14,7 @@
     <body>
         <div class="container">
             <div id="header">
-                <h1>Leaflet TimeDimension example 9</h1>                
+                <h1>Leaflet TimeDimension example 9</h1>
                 <h2>GeoJSON layers with times property</h2>
             </div>
             <div id="map" class="map"></div>
@@ -24,21 +24,21 @@
             <pre><code class="javascript" id="code"></code></pre>
             <div class="disclaimer">
                 Running icon made by <a href="http://www.freepik.com" title="Freepik">Freepik</a> from <a href="http://www.flaticon.com" title="Flaticon">www.flaticon.com</a> is licensed under <a href="http://creativecommons.org/licenses/by/3.0/" title="Creative Commons BY 3.0">CC BY 3.0</a>
-            </div>            
+            </div>
 
             <div class="prev-example">
                 <a href="example8.html">Example 8: SOCIB HF Radar with surface drifters trajectories</a>
-            </div>   
+            </div>
             <div class="next-example">
                 <a href="example10.html">Example 10: ImageOverlay and custom control</a>
             </div>
             <div id="footer">
                 <a class="leaflet-timedimension" href="index.html">Leaflet.TimeDimension examples</a>
                 <a class="github" href="https://github.com/socib/Leaflet.TimeDimension" title="Fork Leaflet.TimeDimension at GitHub!"><span>Fork Leaflet.TimeDimension at GitHub</span></a>
-            </div>                          
+            </div>
         </div>
 
-        <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/2.2.4/jquery.min.js"></script>
+
         <script type="text/javascript" src="https://cdn.rawgit.com/tryone144/dateFormat/master/date.format.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet/0.7.7/leaflet.js"></script>
         <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/leaflet.fullscreen/1.4.2/Control.FullScreen.min.js"></script>
@@ -57,15 +57,15 @@
         <script type="text/javascript" src="js/example9.js"></script>
         <script src="http://cdnjs.cloudflare.com/ajax/libs/highlight.js/8.4/highlight.min.js"></script>
         <script type="text/javascript">
-            $(document).ready(function() {
-                $.ajax('js/example9.js', {dataType: 'script'})
-                    .always(function(response) {                        
-                        $("#code").text(response.responseText);
-                        $('pre code').each(function(i, block) {
-                            hljs.highlightBlock(block);
-                        });
-                    });
-            });
-        </script>        
+            var oReq = new XMLHttpRequest();
+            oReq.addEventListener("load", (function(xhr) {
+                var code = xhr.currentTarget.response;
+                var codeBlock = document.getElementById("code");
+                codeBlock.innerHTML = code;
+                hljs.highlightBlock(codeBlock);
+            }));
+            oReq.open("GET", "js/example9.js");
+            oReq.send();
+        </script>
     </body>
 </html>

--- a/examples/example9.html
+++ b/examples/example9.html
@@ -61,7 +61,7 @@
             oReq.addEventListener("load", (function(xhr) {
                 var code = xhr.currentTarget.response;
                 var codeBlock = document.getElementById("code");
-                codeBlock.innerHTML = code;
+                codeBlock.textContent = code;
                 hljs.highlightBlock(codeBlock);
             }));
             oReq.open("GET", "js/example9.js");

--- a/examples/js/example10.js
+++ b/examples/js/example10.js
@@ -62,7 +62,7 @@ L.TimeDimension.Layer.ImageOverlay = L.TimeDimension.Layer.extend({
             return;
         }
         this._currentLayer = layer;
-        // Cache management        
+        // Cache management
         var times = this._getLoadedTimes();
         var strTime = String(time);
         var index = times.indexOf(strTime);

--- a/examples/js/example12.js
+++ b/examples/js/example12.js
@@ -16,7 +16,6 @@ L.TimeDimension.Layer.SODAHeatMap = L.TimeDimension.Layer.extend({
             lngField: 'lng',
             valueField: 'count'
         };
-        heatmapCfg = $.extend({}, heatmapCfg, options.heatmatOptions || {});
         var layer = new HeatmapOverlay(heatmapCfg);
         L.TimeDimension.Layer.prototype.initialize.call(this, layer, options);
         this._currentLoadedTime = 0;
@@ -112,7 +111,7 @@ currentTime.setUTCDate(1, 0, 0, 0, 0);
 var map = L.map('map', {
     zoom: 12,
     fullscreenControl: true,
-    timeDimension: true,    
+    timeDimension: true,
     timeDimensionOptions: {
         timeInterval: "2010-01-01/" + currentTime.toISOString(),
         period: "P1M",
@@ -133,7 +132,7 @@ map.attributionControl.addAttribution('<a href="https://nycopendata.socrata.com/
 L.Control.TimeDimensionCustom = L.Control.TimeDimension.extend({
     _getDisplayDateFormat: function(date){
         return date.format("mmmm yyyy");
-    }    
+    }
 });
 var timeDimensionControl = new L.Control.TimeDimensionCustom({
     playerOptions: {

--- a/examples/js/example15.js
+++ b/examples/js/example15.js
@@ -69,7 +69,10 @@ var map = L.map('map', {
     center: [39.6145, 1.99363]
 });
 
-$.getJSON('data/spill.json', function(data) {
+var oReq = new XMLHttpRequest();
+oReq.addEventListener("load", (function(xhr) {
+    var response = xhr.currentTarget.response;
+    var data = JSON.parse(response);
     var cdriftLayer = L.geoJson(data, {
         style: function(feature) {
             var color = "#FFF";
@@ -112,13 +115,17 @@ $.getJSON('data/spill.json', function(data) {
         if (data.time == map.timeDimension.getCurrentTime()) {
             var totalTimes = map.timeDimension.getAvailableTimes().length;
             var position = map.timeDimension.getAvailableTimes().indexOf(data.time);
-            $(map.getContainer()).find('.animation-progress-bar').width((position*100)/totalTimes + "%");
+            map.getContainer().querySelector('.animation-progress-bar').style.width = ((position*100)/totalTimes + "%");
             // update map bounding box
             map.fitBounds(cdriftTimeLayer.getBounds());
         }
     });
+}));
+oReq.open("GET", 'data/spill.json');
+oReq.send();
 
-});
+
+
 
 var sorrento = L.circleMarker([39.6145, 1.99363], {
     color: '#FFFFFF',

--- a/examples/js/example7.js
+++ b/examples/js/example7.js
@@ -1,7 +1,7 @@
 var currentTime = new Date();
 currentTime.setUTCHours(0, 0, 0, 0);
 var endDate = new Date(currentTime.getTime());
-L.TimeDimension.Util.addTimeDuration(endDate, "P3D", true);      
+L.TimeDimension.Util.addTimeDuration(endDate, "P3D", true);
 
 var map = L.map('map', {
     zoom: 8,
@@ -14,8 +14,8 @@ var map = L.map('map', {
         period: "PT6H",
         currentTime: currentTime.getTime()
     },
-    timeDimensionControlOptions: {    
-        playerOptions: {                        
+    timeDimensionControlOptions: {
+        playerOptions: {
             loop: true,
             transitionTime: 1500,
             buffer: 10
@@ -27,7 +27,7 @@ var wmopWMS = "http://thredds.socib.es/thredds/wms/operational_models/oceanograp
 var wmopTemperatureLayer = L.tileLayer.wms(wmopWMS, {
     layers: 'temp',
     format: 'image/png',
-    transparent: true,    
+    transparent: true,
     abovemaxcolor: "extend",
     belowmincolor: "extend",
     numcolorbands: 40,
@@ -38,7 +38,7 @@ var wmopTemperatureLayer = L.tileLayer.wms(wmopWMS, {
 var wmopTemperatureContourLayer = L.tileLayer.wms(wmopWMS, {
     layers: 'temp',
     format: 'image/png',
-    transparent: true,    
+    transparent: true,
     numcontours: 11,
     styles: 'contour/sst_36',
     zIndex: 10,
@@ -47,7 +47,7 @@ var wmopTemperatureContourLayer = L.tileLayer.wms(wmopWMS, {
 var wmopSalinityLayer = L.tileLayer.wms(wmopWMS, {
     layers: 'salt',
     format: 'image/png',
-    transparent: true,    
+    transparent: true,
     abovemaxcolor: "extend",
     belowmincolor: "extend",
     numcolorbands: 40,
@@ -57,7 +57,7 @@ var wmopSalinityLayer = L.tileLayer.wms(wmopWMS, {
 var wmopSalinityContourLayer = L.tileLayer.wms(wmopWMS, {
     layers: 'salt',
     format: 'image/png',
-    transparent: true,    
+    transparent: true,
     numcontours: 11,
     styles: 'contour/sst_36'
 });
@@ -71,7 +71,7 @@ var wmopVelocityLayer = L.nonTiledLayer.wms(wmopWMS, {
     belowmincolor: "extend",
     markerscale: 10,
     markerspacing: 8,
-    styles: 'prettyvec/greyscale'    
+    styles: 'prettyvec/greyscale'
 });
 
 var proxy = 'server/proxy.php';
@@ -88,15 +88,18 @@ wmopVelocityTimeLayer.addTo(map);
 
 var getLayerMinMax = function(layer, callback) {
     var url = wmopWMS + '?service=WMS&version=1.1.1&request=GetMetadata&item=minmax';
-    url = url + '&layers=' + layer.options.layers;    
-    url = url + '&srs=EPSG:4326';    
+    url = url + '&layers=' + layer.options.layers;
+    url = url + '&srs=EPSG:4326';
     var size = map.getSize();
     url = url + '&BBox=' + map.getBounds().toBBoxString();
     url = url + '&height=' + size.y;
     url = url + '&width=' + size.x;
     url = proxy + '?url=' + encodeURIComponent(url);
 
-    $.getJSON(url, (function(layer, data) {
+    var oReq = new XMLHttpRequest();
+    oReq.addEventListener("load", (function(xhr) {
+        var response = xhr.currentTarget.response;
+        var data = JSON.parse(response);
         var range = data.max - data.min;
         var min = Math.floor(data.min) - 1;
         var max = Math.floor(data.max + 2);
@@ -105,7 +108,9 @@ var getLayerMinMax = function(layer, callback) {
         if (callback !== undefined) {
             callback();
         }
-    }).bind(this, layer));
+    }));
+    oReq.open("GET", url);
+    oReq.send();
 };
 
 var addTimeDimensionLayer = function(layer, name, addToMap){
@@ -119,11 +124,11 @@ getLayerMinMax(wmopTemperatureLayer, function(){
     addTimeDimensionLayer(wmopTemperatureLayer, 'WMOP - Temperature', true);
     wmopTemperatureContourLayer.wmsParams.colorscalerange = wmopTemperatureLayer.wmsParams.colorscalerange;
     wmopTemperatureContourLayer.options.colorscalerange = wmopTemperatureLayer.wmsParams.colorscalerange;
-    addTimeDimensionLayer(wmopTemperatureContourLayer, 'WMOP - Temperature (Contour)', true);    
+    addTimeDimensionLayer(wmopTemperatureContourLayer, 'WMOP - Temperature (Contour)', true);
 });
 getLayerMinMax(wmopSalinityLayer, function(){
     addTimeDimensionLayer(wmopSalinityLayer, 'WMOP - Salinity', false);
     wmopSalinityContourLayer.wmsParams.colorscalerange = wmopSalinityLayer.wmsParams.colorscalerange;
-    wmopSalinityContourLayer.options.colorscalerange = wmopSalinityLayer.wmsParams.colorscalerange;    
+    wmopSalinityContourLayer.options.colorscalerange = wmopSalinityLayer.wmsParams.colorscalerange;
     addTimeDimensionLayer(wmopSalinityContourLayer, 'WMOP - Salinity (Contour)', false);
 });

--- a/examples/js/extras/leaflet.timedimension.circlelabelmarker.js
+++ b/examples/js/extras/leaflet.timedimension.circlelabelmarker.js
@@ -1,5 +1,5 @@
 /*
- * L.TimeDimension.CircleLabelMarker: circleMarker + divIcon containing 
+ * L.TimeDimension.CircleLabelMarker: circleMarker + divIcon containing
  * the numerical value of the baseLayer (from a THREDDS server).
  */
 
@@ -24,7 +24,7 @@ L.TimeDimension.Layer.CircleLabelMarker = L.TimeDimension.Layer.extend({
                 this._update();
             }).bind(this));
         }else{
-            this._update();            
+            this._update();
         }
 
         return this;
@@ -52,7 +52,7 @@ L.TimeDimension.Layer.CircleLabelMarker = L.TimeDimension.Layer.extend({
         return;
     },
 
-    isReady: function(time) {        
+    isReady: function(time) {
         return this._existsValueForTime(time);
     },
 
@@ -125,7 +125,7 @@ L.TimeDimension.Layer.CircleLabelMarker = L.TimeDimension.Layer.extend({
         if (!this._dataLayer || !this._map || !this._map.getBounds().contains(this._position)){
             if (callback !== undefined) {
                 callback(null);
-            }            
+            }
             return;
         }
         var point = this._map.latLngToContainerPoint(this._position);
@@ -142,10 +142,12 @@ L.TimeDimension.Layer.CircleLabelMarker = L.TimeDimension.Layer.extend({
 
         if (this._proxy) url = this._proxy + '?url=' + encodeURIComponent(url);
 
-        $.get(url, (function(data) {
+        var oReq = new XMLHttpRequest();
+        oReq.addEventListener("load", (function(xhr) {
+            var data = xhr.currentTarget.responseXML;
             var result = null;
-            $(data).find('FeatureInfo').each(function() {
-                var this_data = $(this).find('value').text();
+            data.querySelectorAll('FeatureInfo').forEach(function(fi) {
+                var this_data = fi.querySelector('value').textContent;
                 try {
                     this_data = parseFloat(this_data);
                 } catch (e) {
@@ -158,6 +160,9 @@ L.TimeDimension.Layer.CircleLabelMarker = L.TimeDimension.Layer.extend({
                 callback(result);
             }
         }).bind(this));
+        oReq.overrideMimeType('application/xml');
+        oReq.open("GET", url);
+        oReq.send();
     }
 });
 

--- a/package.json
+++ b/package.json
@@ -31,8 +31,7 @@
   },
   "dependencies": {
     "iso8601-js-period": "0.2.0",
-    "leaflet": "~0.7.4 || ~1.0.0",
-    "jquery": "1.x || 2.x"
+    "leaflet": "~0.7.4 || ~1.0.0"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
Previously @mdartic created a pull request to remove jQuery. Partly based on his request, cleaned and completed a new pull request that removes jQuery from the main libraries and most of the examples. 

Examples 1, 2, 3, 4, 6, 7, 8, 9, 10, 13, 14, 15 and 16 have been tested and found to be working.

Example 5 doesn't work (but is broken at http://apps.socib.es/ as well)
Example 11 doesn't work (but is broken at http://apps.socib.es/ as well)
Example 12 doesn't work (but is broken at http://apps.socib.es/ as well)

Examples 3 and 10 still use jQuery for other tasks.