### PR TITLE
Prefer L.Evented over deprecated L.Mixin.Events

### DIFF
--- a/src/leaflet.timedimension.js
+++ b/src/leaflet.timedimension.js
@@ -8,7 +8,7 @@
 
 L.TimeDimension = (L.Layer || L.Class).extend({
 
-    includes: L.Mixin.Events,
+    includes: (L.Evented || L.Mixin.Events),
 
     initialize: function (options) {
         L.setOptions(this, options);

--- a/src/leaflet.timedimension.layer.js
+++ b/src/leaflet.timedimension.layer.js
@@ -7,7 +7,7 @@
 
 L.TimeDimension.Layer = (L.Layer || L.Class).extend({
 
-    includes: L.Mixin.Events,
+    includes: (L.Evented || L.Mixin.Events),
     options: {
         opacity: 1,
         zIndex: 1

--- a/src/leaflet.timedimension.player.js
+++ b/src/leaflet.timedimension.player.js
@@ -8,7 +8,7 @@
 //'use strict';
 L.TimeDimension.Player = (L.Layer || L.Class).extend({
 
-    includes: L.Mixin.Events,
+    includes: (L.Evented || L.Mixin.Events),
     initialize: function(options, timeDimension) {
         L.setOptions(this, options);
         this._timeDimension = timeDimension;


### PR DESCRIPTION
1.2.0 complained about this. Implemented it with a fallback to the old object for backwards compatibility.

Fixes: 
https://github.com/socib/Leaflet.TimeDimension/issues/114