### PR TITLE
Improve package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "leaflet": "~0.7.4 || ~1"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": "~1",
     "grunt-contrib-clean": "~0.7.0",
-    "grunt-contrib-concat": "~0.5.1",
-    "grunt-contrib-cssmin": "~0.14.0",
-    "grunt-contrib-jshint": "~0.11.3",
+    "grunt-contrib-concat": "~1",
+    "grunt-contrib-cssmin": "~2.2",
+    "grunt-contrib-jshint": "~1.1",
     "grunt-contrib-uglify": "~0.11.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-remove-logging": "~0.2.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "iso8601-js-period": "0.2.0",
-    "leaflet": "~0.7.4 || ~1.0.0"
+    "leaflet": "~0.7.4 || ~1"
   },
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "grunt-contrib-concat": "~1",
     "grunt-contrib-cssmin": "~2.2",
     "grunt-contrib-jshint": "~1.1",
-    "grunt-contrib-uglify": "~0.11.0",
-    "grunt-contrib-watch": "~0.6.1",
+    "grunt-contrib-uglify": "~3.1.0",
+    "grunt-contrib-watch": "~1",
     "grunt-remove-logging": "~0.2.0"
   },
   "main": "dist/leaflet.timedimension.src.js",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,7 @@
     "grunt-contrib-uglify": "~0.11.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-remove-logging": "~0.2.0"
-  }
+  },
+  "main": "dist/leaflet.timedimension.src.js",
+  "style": "dist/leaflet.timedimension.control.css"
 }


### PR DESCRIPTION
leaflet 1.x compatibility in package.json + added main and css to package.json (using these changes I've been able to use it in a ES6-era React project, although it is still uses the (ugly) Leaflet window.L binding.