### PR TITLE
Umdify

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
                     '  // define a Common JS module that relies on leaflet\n' +
                     '  module.exports = factory(require(\'leaflet\'));\n' +
                     '}\n' +
-                    'if (typeof window !== \'undefined\' && window.L) {\n' +
+                    'if (typeof window !== \'undefined\' && window.L && typeof L !== \'undefined\') {\n' +
                     '  // attach your plugin to the global L variable\n' +
                     '  window.L.TimeDimension = factory(L);\n' +
                     '}\n' +
@@ -71,7 +71,8 @@ module.exports = function(grunt) {
         concat: {
             js: {
                 options: {
-                    banner: '<%= meta.banner %>\n<%= umd.prefix %>',
+                    banner: '<%= meta.banner %>\n'+
+                            '<%= umd.prefix %>',
                     footer: '<%= umd.postfix %>'
                 },
                 src: [

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,22 +14,22 @@ module.exports = function(grunt) {
         pkg: grunt.file.readJSON('package.json'),
         umd: {
           prefix: '(function (factory, window) {\n' +
-                    'if (typeof define === \'function\' && define.amd) {\n' +
-                    '  // define an AMD module that relies on leaflet\n' +
-                    '  define([\'leaflet\'], factory);\n' +
-                    '} else if (typeof exports === \'object\') {\n' +
-                    '  // define a Common JS module that relies on leaflet\n' +
-                    '  module.exports = factory(require(\'leaflet\'));\n' +
-                    '}\n' +
-                    'if (typeof window !== \'undefined\' && window.L && typeof L !== \'undefined\') {\n' +
-                    '  // attach your plugin to the global L variable\n' +
-                    '  window.L.TimeDimension = factory(L);\n' +
-                    '}\n' +
-                    '}(function (L) {\n'+
-                    '  // TimeDimension plugin implementation\n',
-          postfix:  '  \n'+
-                    '  return L.TimeDimension;\n'+
-                    '}, window));'
+                    '  if (typeof define === \'function\' && define.amd) {\n' +
+                    '    // define an AMD module that relies on leaflet\n' +
+                    '    define([\'leaflet\'], factory);\n' +
+                    '  } else if (typeof exports === \'object\') {\n' +
+                    '    // define a Common JS module that relies on leaflet\n' +
+                    '    module.exports = factory(require(\'leaflet\'));\n' +
+                    '  } else if (typeof window !== \'undefined\' && window.L && typeof L !== \'undefined\') {\n' +
+                    '    // attach your plugin to the global L variable\n' +
+                    '    window.L.TimeDimension = factory(L);\n' +
+                    '  }\n' +
+                    '  }(function (L) {\n'+
+                    '    // TimeDimension plugin implementation\n',
+          postfix:  '    \n'+
+                    '    return L.TimeDimension;\n'+
+                    '  }, window)\n'+
+                    ');'
         },
         meta: {
             banner: '/* \n' +

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,15 +21,15 @@ module.exports = function(grunt) {
                     '    // define a Common JS module that relies on leaflet\n' +
                     '    module.exports = factory(require(\'leaflet\'), require(\'iso8601-js-period\'));\n' +
                     '  } else if (typeof window !== \'undefined\' && window.L && typeof L !== \'undefined\') {\n' +
-                    '    // get the iso8601 from the expected to be global nezesa scope\n' +
-                    '    var iso8601 = nezesa.iso8601;\n' +
+                    '    // get the iso8601 from the expected to be global nezasa scope\n' +
+                    '    var iso8601 = nezasa.iso8601;\n' +
                     '    // attach your plugin to the global L variable\n' +
                     '    window.L.TimeDimension = factory(L, iso8601);\n' +
                     '  }\n' +
                     '  }(function (L, iso8601) {\n'+
-                    '    // make sure iso8601 module js period module is available under the nezesa scope\n'+
-                    '    if (typeof nezesa === \'undefined\') {\n'+
-                    '      var nezesa = { iso8601: iso8601 };\n'+
+                    '    // make sure iso8601 module js period module is available under the nezasa scope\n'+
+                    '    if (typeof nezasa === \'undefined\') {\n'+
+                    '      var nezasa = { iso8601: iso8601 };\n'+
                     '    }\n'+
                     '    // TimeDimension plugin implementation\n',
           postfix:  '    \n'+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -16,15 +16,21 @@ module.exports = function(grunt) {
           prefix: '(function (factory, window) {\n' +
                     '  if (typeof define === \'function\' && define.amd) {\n' +
                     '    // define an AMD module that relies on leaflet\n' +
-                    '    define([\'leaflet\'], factory);\n' +
+                    '    define([\'leaflet\', \'iso8601-js-period\'], factory);\n' +
                     '  } else if (typeof exports === \'object\') {\n' +
                     '    // define a Common JS module that relies on leaflet\n' +
-                    '    module.exports = factory(require(\'leaflet\'));\n' +
+                    '    module.exports = factory(require(\'leaflet\'), require(\'iso8601-js-period\'));\n' +
                     '  } else if (typeof window !== \'undefined\' && window.L && typeof L !== \'undefined\') {\n' +
+                    '    // get the iso8601 from the expected to be global nezesa scope\n' +
+                    '    var iso8601 = nezesa.iso8601;\n' +
                     '    // attach your plugin to the global L variable\n' +
-                    '    window.L.TimeDimension = factory(L);\n' +
+                    '    window.L.TimeDimension = factory(L, iso8601);\n' +
                     '  }\n' +
-                    '  }(function (L) {\n'+
+                    '  }(function (L, iso8601) {\n'+
+                    '    // make sure iso8601 module js period module is available under the nezesa scope\n'+
+                    '    if (typeof nezesa === \'undefined\') {\n'+
+                    '      var nezesa = { iso8601: iso8601 };\n'+
+                    '    }\n'+
                     '    // TimeDimension plugin implementation\n',
           postfix:  '    \n'+
                     '    return L.TimeDimension;\n'+

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -12,6 +12,25 @@ module.exports = function(grunt) {
 
     grunt.initConfig({
         pkg: grunt.file.readJSON('package.json'),
+        umd: {
+          prefix: '(function (factory, window) {\n' +
+                    'if (typeof define === \'function\' && define.amd) {\n' +
+                    '  // define an AMD module that relies on leaflet\n' +
+                    '  define([\'leaflet\'], factory);\n' +
+                    '} else if (typeof exports === \'object\') {\n' +
+                    '  // define a Common JS module that relies on leaflet\n' +
+                    '  module.exports = factory(require(\'leaflet\'));\n' +
+                    '}\n' +
+                    'if (typeof window !== \'undefined\' && window.L) {\n' +
+                    '  // attach your plugin to the global L variable\n' +
+                    '  window.L.TimeDimension = factory(L);\n' +
+                    '}\n' +
+                    '}(function (L) {\n'+
+                    '  // TimeDimension plugin implementation\n',
+          postfix:  '  \n'+
+                    '  return L.TimeDimension;\n'+
+                    '}, window));'
+        },
         meta: {
             banner: '/* \n' +
                 ' * Leaflet TimeDimension v<%= pkg.version %> - <%= grunt.template.today("yyyy-mm-dd") %> \n' +
@@ -52,7 +71,8 @@ module.exports = function(grunt) {
         concat: {
             js: {
                 options: {
-                    banner: '<%= meta.banner %>'
+                    banner: '<%= meta.banner %>\n<%= umd.prefix %>',
+                    footer: '<%= umd.postfix %>'
                 },
                 src: [
                     'src/leaflet.timedimension.js',

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "email": "datacenter@socib.es",
     "url": "http://www.socib.es/"
   },
-  "contributors":[
+  "contributors": [
     {
       "name": "Sylvain Marcadal (Ram)",
       "email": "sylvain@marcadal.me",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "url": "git://github.com/socib/Leaflet.TimeDimension.git"
   },
   "dependencies": {
-    "iso8601-js-period": "0.2.0",
+    "iso8601-js-period": "^0.2.1",
     "leaflet": "~0.7.4 || ~1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -34,11 +34,11 @@
     "leaflet": "~0.7.4 || ~1"
   },
   "devDependencies": {
-    "grunt": "~0.4.5",
+    "grunt": "~1",
     "grunt-contrib-clean": "~0.7.0",
-    "grunt-contrib-concat": "~0.5.1",
-    "grunt-contrib-cssmin": "~0.14.0",
-    "grunt-contrib-jshint": "~0.11.3",
+    "grunt-contrib-concat": "~1",
+    "grunt-contrib-cssmin": "~2.2",
+    "grunt-contrib-jshint": "~1.1",
     "grunt-contrib-uglify": "~0.11.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-remove-logging": "~0.2.0"

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   },
   "dependencies": {
     "iso8601-js-period": "0.2.0",
-    "leaflet": "~0.7.4 || ~1.0.0"
+    "leaflet": "~0.7.4 || ~1"
   },
   "devDependencies": {
     "grunt": "~0.4.5",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "grunt-contrib-concat": "~1",
     "grunt-contrib-cssmin": "~2.2",
     "grunt-contrib-jshint": "~1.1",
-    "grunt-contrib-uglify": "~0.11.0",
-    "grunt-contrib-watch": "~0.6.1",
+    "grunt-contrib-uglify": "~3.1.0",
+    "grunt-contrib-watch": "~1",
     "grunt-remove-logging": "~0.2.0"
   },
   "main": "dist/leaflet.timedimension.src.js",

--- a/package.json
+++ b/package.json
@@ -42,5 +42,7 @@
     "grunt-contrib-uglify": "~0.11.0",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-remove-logging": "~0.2.0"
-  }
+  },
+  "main": "dist/leaflet.timedimension.src.js",
+  "style": "dist/leaflet.timedimension.control.css"
 }


### PR DESCRIPTION
This pull requests builds on a previous (but unmerged) pull request (https://github.com/socib/Leaflet.TimeDimension/pull/125) and improves compatibility with different methods of packaging by wrapping it in slightly adjusted UMD-boilerplate code [as suggested by the Leaflet documentation](https://github.com/Leaflet/Leaflet/blob/master/PLUGIN-GUIDE.md#module-loaders)

With [this leaflet pull request being merged](https://github.com/Leaflet/Leaflet/pull/5901) it would allow for a problemless use in a modern ES6 workflow with es-modules with browserless unit-tests.

Note that it doesn't change behaviour when used in a front-end only setting, where a global `L`-variable is still available to plugins.