### PR TITLE
Faster handling of large geoJson layers

### DIFF
--- a/src/leaflet.timedimension.util.js
+++ b/src/leaflet.timedimension.util.js
@@ -197,10 +197,13 @@ L.TimeDimension.Util = {
 
     sort_and_deduplicate: function(arr) {
         arr = arr.slice(0).sort();
-        var result = arr.slice(0, 1);
-        for (var i = 1, l = arr.length; i < l; i++) {
-            if (arr[i] !== result[i-1])
+        var result = [];
+        var last = null;
+        for (var i = 0, l = arr.length; i < l; i++) {
+            if (arr[i] !== last){
                 result.push(arr[i]);
+                last = arr[i];
+            }
         }
         return result;
     }

--- a/src/leaflet.timedimension.util.js
+++ b/src/leaflet.timedimension.util.js
@@ -193,6 +193,16 @@ L.TimeDimension.Util = {
             result = result.concat(b);
         }
         return result;
+    },
+
+    sort_and_deduplicate: function(arr) {
+        arr = arr.slice(0).sort();
+        var result = arr.slice(0, 1);
+        for (var i = 1, l = arr.length; i < l; i++) {
+            if (arr[i] !== result[i-1])
+                result.push(arr[i]);
+        }
+        return result;
     }
 
 };


### PR DESCRIPTION
I had some performance issues when using a large data file tracking GPS positions of cars. The file has around 200 long LineStrings. I changed the algorithm as follows -
1) When computing available times, it's possible to unite the arrays using only 2 passes, speeding up the loading from several minutes to 1-2 seconds
2) Not parsing the date strings on every frame update, this cut the CPU usage by 50% on my machine

Hope others can use this as well.

One downside - since the timestamps for each feature are now cached, you can't modify features inside the JSON itself. The only way to change it is to remove features and add new ones in their place. (I can't think of a use case where the features change anyway)