### PR TITLE
The control was not updating its own options object on init.

### DIFF
--- a/src/leaflet.timedimension.control.js
+++ b/src/leaflet.timedimension.control.js
@@ -136,6 +136,7 @@ L.Control.TimeDimension = L.Control.extend({
     },
 
     initialize: function(options) {
+        L.setOptions(options);
         L.Control.prototype.initialize.call(this, options);
         this._timeZoneIndex = 0;
         this._timeDimension = this.options.timeDimension || null;


### PR DESCRIPTION
The control's constructor parameter options object never overwrote the default one. This resolves Issues #142.