### PR TITLE
Fix issue with entire GeoJSON being displayed at last feature time

### DIFF
--- a/src/leaflet.timedimension.layer.geojson.js
+++ b/src/leaflet.timedimension.layer.geojson.js
@@ -162,10 +162,10 @@ L.TimeDimension.Layer.GeoJson = L.TimeDimension.Layer.extend({
             return null;
         }
 
-        if (featureTimes[l - 1] > minTime) {
+        if (featureTimes[l - 1] >= minTime) {
             for (var i = 0; i < l; i++) {
-                if (index_min === null && featureTimes[i] > minTime) {
-                    // set index_min the first time that current time is greater the minTime
+                if (index_min === null && featureTimes[i] >= minTime) {
+                    // set index_min the first time that current time is greater or equal to the minTime
                     index_min = i;
                 }
                 if (featureTimes[i] > maxTime) {


### PR DESCRIPTION
When a last feature time is equal to the current min_time, the current logic leaves min_index set to null. This then sets the min_index to 0, and such the entire layer is erroneously displayed.

This change simply changes to check the feature time is greater than **or equal to** to the min time.