### PR TITLE
removed queryable=1 selector for time dimension parsing

### DIFF
--- a/dist/leaflet.timedimension.src.js
+++ b/dist/leaflet.timedimension.src.js
@@ -1042,7 +1042,7 @@ L.TimeDimension.Layer.WMS = L.TimeDimension.Layer.extend({
     },
 
     _parseTimeDimensionFromCapabilities: function(xml) {
-        var layers = xml.querySelectorAll('Layer[queryable="1"]');
+        var layers = xml.querySelectorAll('Layer');
         var layerName = this._baseLayer.wmsParams.layers;
         var layer = null;
         var times = null;


### PR DESCRIPTION
According to OGC WMS specification v. 1.1.0 and 1.3.0 the ``queryable=1`` attribute of a layer signifies if a WMS supports  ``GetFeatureInfo`` operation. A layer can have a time dimension without supporting the ``GetFeatureInfo`` operation, therefore  ``queryable=1`` is not necessary as the existing code additionally checks for the existence of a time dimension.

This problem was already raised in the following issue #139. This pull request provides the suggested fix.

Thank you for your great work!