### PR TITLE
small fix for case when buffer size is larger then the actual  availa…

### DIFF
--- a/src/leaflet.timedimension.player.js
+++ b/src/leaflet.timedimension.player.js
@@ -48,7 +48,7 @@ L.TimeDimension.Player = (L.Layer || L.Class).extend({
             return;
         }
         var numberNextTimesReady = 0,
-            buffer = this._bufferSize;
+            buffer = Math.min(this._bufferSize, this._getMaxIndex());
 
         if (this._minBufferReady > 0) {
             numberNextTimesReady = this._timeDimension.getNumberNextTimesReady(this._steps, buffer, this._loop);


### PR DESCRIPTION
…ble times

I hit a small bug when the configured buffer size was larger then length of the actual available times array. Some times when preloading the steps, the plugin keeps on firing the "waiting" event. Setting a Math.min on the buffer size , comparing with the _getMaxIndex() should fix it.

